### PR TITLE
Add pytest tests for todo endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Python cache files
+__pycache__/
+*.py[cod]
+
+# SQLite database
+*.db
+
+# pytest cache
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a simple cross-platform Todo List web application built with Flask and S
 
 ## Features
 
-- Add, complete, and delete tasks
+- Add, edit, complete, and delete tasks
 - Data stored locally using SQLite
 - Minimal Bootstrap-based UI
 

--- a/README.md
+++ b/README.md
@@ -40,3 +40,12 @@ gunicorn -w 4 -b 0.0.0.0:8000 app.routes:app
 ```
 
 This will serve the application on port 8000 using 4 worker processes.
+
+## Running tests
+
+Install `pytest` and run the suite:
+
+```bash
+pip install pytest
+pytest
+```

--- a/app/routes.py
+++ b/app/routes.py
@@ -18,6 +18,16 @@ def add_todo():
         db.session.commit()
     return redirect(url_for('index'))
 
+
+@app.route('/edit/<int:todo_id>', methods=['POST'])
+def edit_todo(todo_id):
+    todo = Todo.query.get_or_404(todo_id)
+    title = request.form.get('title')
+    if title:
+        todo.title = title
+        db.session.commit()
+    return redirect(url_for('index'))
+
 @app.route('/toggle/<int:todo_id>')
 def toggle_todo(todo_id):
     todo = Todo.query.get_or_404(todo_id)

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,4 @@
-from flask import render_template, request, redirect, url_for
+from flask import render_template, request, redirect, url_for, abort
 from . import create_app, db
 from .models import Todo
 
@@ -21,7 +21,9 @@ def add_todo():
 
 @app.route('/edit/<int:todo_id>', methods=['POST'])
 def edit_todo(todo_id):
-    todo = Todo.query.get_or_404(todo_id)
+    todo = db.session.get(Todo, todo_id)
+    if not todo:
+        abort(404)
     title = request.form.get('title')
     if title:
         todo.title = title
@@ -30,14 +32,18 @@ def edit_todo(todo_id):
 
 @app.route('/toggle/<int:todo_id>')
 def toggle_todo(todo_id):
-    todo = Todo.query.get_or_404(todo_id)
+    todo = db.session.get(Todo, todo_id)
+    if not todo:
+        abort(404)
     todo.completed = not todo.completed
     db.session.commit()
     return redirect(url_for('index'))
 
 @app.route('/delete/<int:todo_id>')
 def delete_todo(todo_id):
-    todo = Todo.query.get_or_404(todo_id)
+    todo = db.session.get(Todo, todo_id)
+    if not todo:
+        abort(404)
     db.session.delete(todo)
     db.session.commit()
     return redirect(url_for('index'))

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -30,7 +30,7 @@ def test_edit_todo(client):
     response = client.post(f'/edit/{todo_id}', data={'title': 'New'}, follow_redirects=True)
     assert response.status_code == 200
     with app.app_context():
-        updated = Todo.query.get(todo_id)
+        updated = db.session.get(Todo, todo_id)
         assert updated.title == 'New'
 
 def test_toggle_todo(client):
@@ -42,7 +42,7 @@ def test_toggle_todo(client):
     response = client.get(f'/toggle/{todo_id}', follow_redirects=True)
     assert response.status_code == 200
     with app.app_context():
-        toggled = Todo.query.get(todo_id)
+        toggled = db.session.get(Todo, todo_id)
         assert toggled.completed
 
 def test_delete_todo(client):
@@ -54,4 +54,4 @@ def test_delete_todo(client):
     response = client.get(f'/delete/{todo_id}', follow_redirects=True)
     assert response.status_code == 200
     with app.app_context():
-        assert Todo.query.get(todo_id) is None
+        assert db.session.get(Todo, todo_id) is None

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,57 @@
+import pytest
+from app.routes import app, db
+from app.models import Todo
+
+@pytest.fixture
+def client():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+def test_add_todo(client):
+    response = client.post('/add', data={'title': 'Task 1'}, follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        todo = Todo.query.filter_by(title='Task 1').first()
+        assert todo is not None
+        assert not todo.completed
+
+def test_edit_todo(client):
+    with app.app_context():
+        todo = Todo(title='Old')
+        db.session.add(todo)
+        db.session.commit()
+        todo_id = todo.id
+    response = client.post(f'/edit/{todo_id}', data={'title': 'New'}, follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        updated = Todo.query.get(todo_id)
+        assert updated.title == 'New'
+
+def test_toggle_todo(client):
+    with app.app_context():
+        todo = Todo(title='Toggle')
+        db.session.add(todo)
+        db.session.commit()
+        todo_id = todo.id
+    response = client.get(f'/toggle/{todo_id}', follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        toggled = Todo.query.get(todo_id)
+        assert toggled.completed
+
+def test_delete_todo(client):
+    with app.app_context():
+        todo = Todo(title='Delete')
+        db.session.add(todo)
+        db.session.commit()
+        todo_id = todo.id
+    response = client.get(f'/delete/{todo_id}', follow_redirects=True)
+    assert response.status_code == 200
+    with app.app_context():
+        assert Todo.query.get(todo_id) is None


### PR DESCRIPTION
## Summary
- implement `/edit/<int:todo_id>` route
- add pytest-based tests for add, edit, toggle and delete
- describe running tests in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684396a41e808329af03dc36aa2c06e8