### PR TITLE
Enable CSRF protection

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,17 +1,26 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flask_wtf import CSRFProtect
 from pathlib import Path
+import os
 
 BASE_DIR = Path(__file__).resolve().parent
 DB_PATH = BASE_DIR / 'todo.db'
 
 db = SQLAlchemy()
+csrf = CSRFProtect()
+
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key')
+    SQLALCHEMY_DATABASE_URI = f'sqlite:///{DB_PATH}'
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 
 def create_app():
     app = Flask(__name__)
-    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{DB_PATH}'
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config.from_object(Config)
 
     db.init_app(app)
+    csrf.init_app(app)
     return app

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -9,6 +9,7 @@
 <body class="p-4">
   <h1 class="mb-4">Todo List</h1>
   <form action="{{ url_for('add_todo') }}" method="post" class="mb-3">
+    {{ csrf_token() }}
     <div class="input-group">
       <input type="text" name="title" class="form-control" placeholder="New task" required>
       <button class="btn btn-primary" type="submit">Add</button>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.0.0
 Flask_SQLAlchemy==3.0.5
+Flask-WTF==1.2.2


### PR DESCRIPTION
## Summary
- add `Flask-WTF` requirement
- configure app with a `SECRET_KEY`
- enable `CSRFProtect`
- include CSRF token in HTML form

## Testing
- `pip install -r requirements.txt`
- `python -m flask --version`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684396a4b80c8329a5590fd3738fa63b